### PR TITLE
be compatible with depth 1 layout

### DIFF
--- a/template/hooks/php/doctrine/post-checkout
+++ b/template/hooks/php/doctrine/post-checkout
@@ -2,7 +2,12 @@
 . "$GIT_DIR/hooks/change_detector.sh"
 . "$GIT_DIR/hooks/php/doctrine/update-schema"
 
-if has_changed post-checkout composer.lock src/*/*/Entity src/*/*/Resources/config/doctrine
+if has_changed post-checkout \
+	composer.lock \
+	src/*/*/Entity \
+	src/*/*/Resources/config/doctrine \
+	src/*/Entity \
+	src/*/Resources/config/doctrine
 then
 	updateSchema
 fi

--- a/template/hooks/php/doctrine/post-commit
+++ b/template/hooks/php/doctrine/post-commit
@@ -2,7 +2,12 @@
 . "$GIT_DIR/hooks/change_detector.sh"
 . "$GIT_DIR/hooks/php/doctrine/update-schema"
 
-if has_changed post-commit composer.lock src/*/*/Entity src/*/*/Resources/config/doctrine
+if has_changed post-commit \
+	composer.lock \
+	src/*/*/Entity \
+	src/*/*/Resources/config/doctrine \
+	src/*/Entity \
+	src/*/Resources/config/doctrine
 then
 	updateSchema
 fi


### PR DESCRIPTION
The best practices document recommends to have an AppBundle directory
directly in src. Also, there can be other directories, like "Application"
from sonata at depth 1.