### PR TITLE
do not run pre-commit hooks while cherry-picking

### DIFF
--- a/template/hooks/pre-commit
+++ b/template/hooks/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/bash
+test -f "$GIT_DIR"/CHERRY_PICK_HEAD && exit 0
 for enabled_plugin in $(git config --get-all hooks.enabled-plugins)
 do
 	if [ -f "$GIT_DIR/hooks/$enabled_plugin/pre-commit" ]


### PR DESCRIPTION
cherry-pick does not have a --no-verify option, which means if there is
a problem, checks cannot be bypassed.