### PR TITLE
make sure ctags is not run in parallel

### DIFF
--- a/template/hooks/php/ctags/update-ctags
+++ b/template/hooks/php/ctags/update-ctags
@@ -16,6 +16,7 @@ build_ctags_command()
 	fi
 
 	local command=$(cat <<-EOT
+		flock --nonblock /tmp/git-template-ctags.lock
 		ctags
 			-h ".php"
 			--recurse


### PR DESCRIPTION
This can happen when quickly commiting/amending commits.