### PR TITLE
Junkchecker check whole phrasefile line

### DIFF
--- a/template/hooks/junkchecker/pre-commit
+++ b/template/hooks/junkchecker/pre-commit
@@ -12,9 +12,8 @@ then
 	for FILE in $(git diff-index --cached --name-status $against -- | cut -c 3-); do
 		if [ -f "$FILE" ]
 		then
-			for line in $(cat "$junkchecker_phrases_file")
+			while IFS='' read -r line || [[ -n "$line" ]];
 			do
-
 				git diff --cached --diff-filter=ACMR "$FILE" | grep -E '^\+' | grep --quiet "$line"
 				if [ $? -eq 0 ]
 				then
@@ -24,7 +23,7 @@ then
 					EOT
 					exit 1
 				fi
-			done
+			done < "$junkchecker_phrases_file"
 		fi
 	done
 else

--- a/tests/junkchecker_test.sh
+++ b/tests/junkchecker_test.sh
@@ -49,6 +49,18 @@ testExitsWithCodeEqualToZeroWhenJunkIsRemovedAndNotAdded()
 	assertEquals "The junkchecker should be ok with this commit" 0 $rtrn
 }
 
+testMultiWordPattern()
+{
+	initRepo
+	echo "var_dump" > junk-phrases
+	echo "remove this debug line" >> junk-phrases
+	echo "// TODO remove this debug line" > someFile
+	git add someFile
+	git commit --message "Let's commit something we shouldn't" 1> /dev/null 2> "${stderrF}"
+	rtrn=$?
+	assertEquals "The junkchecker detected the junk" 1 $rtrn
+}
+
 initRepo()
 {
 	cd "$testRepo"


### PR DESCRIPTION
Part of my PHP debugging snippet is a comment as a reminder and it's useful for grepping
```
echo $test_var;exit; // @TODO remove this debug line
```
So I added `remove this debug line` to junkchecker's phrasefile, but the result of pre-commit was
```
Junk checker detected: test_junkchecker.php contains 'remove'.
```

With this PR it's
```
Junk checker detected: test_junkchecker.php contains 'remove this debug line'.
```