### PR TITLE
Revert to original update script

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,8 +41,16 @@ cd $(git config --path --get init.templatedir)
 git pull
 ```
 
-Then, you can update any repository by running `git init` from within it.
-Don't fear, [it is perfectly safe][init-manpage].
+Then, you can update any repository by running this in the working tree of your
+repository :
+
+```sh
+$(git config --path --get init.templatedir)/../update.sh
+# If your template directory is ~/.git_template/template, this is equivalent to :
+~/.git_template/update.sh
+```
+
+Make sure you have rsync installed.
 
 ## Setup on existing projects
 
@@ -50,4 +58,3 @@ You can also run the update script from a project created before your switch
 to `git_template`, but be aware that any hook you created yourself will be deleted.
 
 [0]: https://github.com/greg0ire/git_template
-[init-manpage]: https://git-scm.com/docs/git-init

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,13 @@
 #!/bin/bash -eu
 main()
 {
-	echo This script is deprecated. Please run git init instead.
-	git init
+	local templateDir=$(git config --get --path init.templatedir)
+
+	if [ ! -d .git ]
+	then
+		echo "This script is supposed to be run at the root of a git repository" >&2
+	fi
+	rsync --archive --verbose --compress --cvs-exclude "$templateDir/hooks/" .git/hooks --delete
+	cp -f "$templateDir/configure.sh" .git
 }
 main


### PR DESCRIPTION
git init is not able to overwrite existing hooks, which means once you
can't get updates unless it is a new file