### PR TITLE
Replace git-rev-parse with git rev-parse

### DIFF
--- a/template/hooks/junkchecker/pre-commit
+++ b/template/hooks/junkchecker/pre-commit
@@ -4,7 +4,7 @@ GIT_DIR=$(git rev-parse --git-common-dir)
 get_hook_config junkchecker phrasesfile junkchecker_phrases_file required
 if [ -f "$junkchecker_phrases_file" ]
 then
-	if git-rev-parse --verify HEAD >/dev/null 2>&1; then
+	if git rev-parse --verify HEAD >/dev/null 2>&1; then
 		against=HEAD
 	else
 		against=4b825dc642cb6eb9a060e54bf8d69288fbee4904

--- a/template/hooks/syntaxchecker/pre-commit
+++ b/template/hooks/syntaxchecker/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 GIT_DIR=$(git rev-parse --git-common-dir)
 . "$GIT_DIR/hooks/git_config_wrapper.sh"
-if git-rev-parse --verify HEAD >/dev/null 2>&1; then
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
 	against=HEAD
 else
 	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904


### PR DESCRIPTION
I suspect it was somehow working at some point. That file exists on my
system (in /usr/libexec/git-core), but is not in my $PATH, so maybe just
the location changed.