### PR TITLE
Use GIT_COMMON_DIR wherever possible

### DIFF
--- a/template/configure.sh
+++ b/template/configure.sh
@@ -2,10 +2,10 @@
 
 readonly PROGNAME=$(basename "$0")
 readonly PROGDIR="$(cd "$(dirname "$0")"; pwd)"
-readonly GIT_DIR="$(git rev-parse --git-common-dir)"
-export GIT_DIR
+readonly GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+export GIT_COMMON_DIR
 
-. "$GIT_DIR/hooks/hook_switcher.sh"
+. "$GIT_COMMON_DIR/hooks/hook_switcher.sh"
 
 main() {
 	local hookName

--- a/template/hooks/commit-msg
+++ b/template/hooks/commit-msg
@@ -1,10 +1,10 @@
 #!/bin/bash
-GIT_DIR=$(git rev-parse --git-common-dir)
-test -d "$GIT_DIR"/rebase-merge -o -d "$GIT_DIR"/rebase-apply && exit 0
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+test -d "$GIT_COMMON_DIR"/rebase-merge -o -d "$GIT_COMMON_DIR"/rebase-apply && exit 0
 for enabled_plugin in $(git config --get-all hooks.enabled-plugins)
 do
-	if [ -f "$GIT_DIR/hooks/$enabled_plugin/commit-msg" ]
+	if [ -f "$GIT_COMMON_DIR/hooks/$enabled_plugin/commit-msg" ]
 	then
-		"$GIT_DIR/hooks/$enabled_plugin/commit-msg" "$1" "$2"
+		"$GIT_COMMON_DIR/hooks/$enabled_plugin/commit-msg" "$1" "$2"
 	fi
 done

--- a/template/hooks/junkchecker/pre-commit
+++ b/template/hooks/junkchecker/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
-GIT_DIR=$(git rev-parse --git-common-dir)
-. "$GIT_DIR/hooks/git_config_wrapper.sh"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+. "$GIT_COMMON_DIR/hooks/git_config_wrapper.sh"
 get_hook_config junkchecker phrasesfile junkchecker_phrases_file required
 if [ -f "$junkchecker_phrases_file" ]
 then

--- a/template/hooks/make/pre-commit
+++ b/template/hooks/make/pre-commit
@@ -1,11 +1,11 @@
 #!/bin/bash
 # shellcheck source=../git_config_wrapper.sh
-GIT_DIR=$(git rev-parse --git-common-dir)
-. "$GIT_DIR/hooks/git_config_wrapper.sh"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+. "$GIT_COMMON_DIR/hooks/git_config_wrapper.sh"
 
 get_hook_config make on hooks optional "pre-push"
 
 if echo "$hooks"|grep --quiet pre-commit > /dev/null
 then
-	. "$GIT_DIR/hooks/make/run-make"
+	. "$GIT_COMMON_DIR/hooks/make/run-make"
 fi

--- a/template/hooks/php/composer/post-checkout
+++ b/template/hooks/php/composer/post-checkout
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
-. "$GIT_DIR/hooks/change_detector.sh"
-. "$GIT_DIR/hooks/php/composer/react.sh"
+. "$GIT_COMMON_DIR/hooks/change_detector.sh"
+. "$GIT_COMMON_DIR/hooks/php/composer/react.sh"
 
 if [ -f composer.lock ]
 then

--- a/template/hooks/php/composer/post-merge
+++ b/template/hooks/php/composer/post-merge
@@ -1,6 +1,6 @@
 #!/bin/bash
-. "$GIT_DIR/hooks/change_detector.sh"
-. "$GIT_DIR/hooks/php/composer/react.sh"
+. "$GIT_COMMON_DIR/hooks/change_detector.sh"
+. "$GIT_COMMON_DIR/hooks/php/composer/react.sh"
 
 if has_changed post-merge composer.lock
 then

--- a/template/hooks/php/composer/pre-commit
+++ b/template/hooks/php/composer/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
-GIT_DIR=$(git rev-parse --git-common-dir)
-. "$GIT_DIR/hooks/change_detector.sh"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+. "$GIT_COMMON_DIR/hooks/change_detector.sh"
 
 if has_changed pre-commit composer.json
 then

--- a/template/hooks/php/composer/react.sh
+++ b/template/hooks/php/composer/react.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $GIT_DIR/hooks/git_config_wrapper.sh
+. $GIT_COMMON_DIR/hooks/git_config_wrapper.sh
 
 function react()
 {

--- a/template/hooks/php/cs-fixer/fix-cs
+++ b/template/hooks/php/cs-fixer/fix-cs
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-. "$GIT_DIR/hooks/git_config_wrapper.sh"
+. "$GIT_COMMON_DIR/hooks/git_config_wrapper.sh"
 
 fix_cs()
 {

--- a/template/hooks/php/cs-fixer/pre-commit
+++ b/template/hooks/php/cs-fixer/pre-commit
@@ -1,8 +1,8 @@
 #!/bin/bash
-GIT_DIR=$(git rev-parse --git-common-dir)
-. "$GIT_DIR/hooks/change_detector.sh"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+. "$GIT_COMMON_DIR/hooks/change_detector.sh"
 
 if has_changed pre-commit '**/*.php' '*.php'
 then
-	"$GIT_DIR/hooks/php/cs-fixer/fix-cs"
+	"$GIT_COMMON_DIR/hooks/php/cs-fixer/fix-cs"
 fi

--- a/template/hooks/php/ctags/configure.sh
+++ b/template/hooks/php/ctags/configure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -u
-. "$GIT_DIR/hooks/hook_switcher.sh"
+. "$GIT_COMMON_DIR/hooks/hook_switcher.sh"
 
 main() {
 	local projectType

--- a/template/hooks/php/ctags/post-checkout
+++ b/template/hooks/php/ctags/post-checkout
@@ -1,2 +1,2 @@
 #!/bin/bash
-"$GIT_DIR/hooks/php/ctags/update-ctags" >/dev/null 2>&1 &
+"$GIT_COMMON_DIR/hooks/php/ctags/update-ctags" >/dev/null 2>&1 &

--- a/template/hooks/php/ctags/post-commit
+++ b/template/hooks/php/ctags/post-commit
@@ -1,2 +1,2 @@
 #!/bin/bash
-"$GIT_DIR/hooks/php/ctags/update-ctags" >/dev/null 2>&1 &
+"$GIT_COMMON_DIR/hooks/php/ctags/update-ctags" >/dev/null 2>&1 &

--- a/template/hooks/php/ctags/post-merge
+++ b/template/hooks/php/ctags/post-merge
@@ -1,2 +1,2 @@
 #!/bin/bash
-"$GIT_DIR/hooks/php/ctags/update-ctags" >/dev/null 2>&1 &
+"$GIT_COMMON_DIR/hooks/php/ctags/update-ctags" >/dev/null 2>&1 &

--- a/template/hooks/php/doctrine/post-checkout
+++ b/template/hooks/php/doctrine/post-checkout
@@ -1,6 +1,6 @@
 #!/bin/bash
-. "$GIT_DIR/hooks/change_detector.sh"
-. "$GIT_DIR/hooks/php/doctrine/update-schema"
+. "$GIT_COMMON_DIR/hooks/change_detector.sh"
+. "$GIT_COMMON_DIR/hooks/php/doctrine/update-schema"
 
 if has_changed post-checkout \
 	composer.lock \

--- a/template/hooks/php/doctrine/post-commit
+++ b/template/hooks/php/doctrine/post-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
-. "$GIT_DIR/hooks/change_detector.sh"
-. "$GIT_DIR/hooks/php/doctrine/update-schema"
+. "$GIT_COMMON_DIR/hooks/change_detector.sh"
+. "$GIT_COMMON_DIR/hooks/php/doctrine/update-schema"
 
 if has_changed post-commit \
 	composer.lock \

--- a/template/hooks/php/doctrine/update-schema
+++ b/template/hooks/php/doctrine/update-schema
@@ -1,5 +1,5 @@
 #!/bin/bash -u
-. "$GIT_DIR/hooks/git_config_wrapper.sh"
+. "$GIT_COMMON_DIR/hooks/git_config_wrapper.sh"
 
 updateSchema()
 {

--- a/template/hooks/php/sismo/build-project
+++ b/template/hooks/php/sismo/build-project
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $GIT_DIR/hooks/git_config_wrapper.sh
+. $GIT_COMMON_DIR/hooks/git_config_wrapper.sh
 get_hook_config php-sismo path path required
 path_is_defined=$?
 get_hook_config php-sismo slug slug required

--- a/template/hooks/php/sismo/configure.sh
+++ b/template/hooks/php/sismo/configure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $GIT_DIR/hooks/hook_switcher.sh
+. $GIT_COMMON_DIR/hooks/hook_switcher.sh
 
 main() {
 	if hook_is_enabled php/sismo

--- a/template/hooks/php/sismo/post-commit
+++ b/template/hooks/php/sismo/post-commit
@@ -1,3 +1,2 @@
 #!/bin/bash
-$GIT_DIR/hooks/php/sismo/build-project
-
+$GIT_COMMON_DIR/hooks/php/sismo/build-project

--- a/template/hooks/post-checkout
+++ b/template/hooks/post-checkout
@@ -1,11 +1,11 @@
 #!/bin/bash -eu
-GIT_DIR=$(git rev-parse --git-common-dir)
-export GIT_DIR
-test -d "$GIT_DIR"/rebase-merge -o -d "$GIT_DIR"/rebase-apply && exit 0
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+export GIT_COMMON_DIR
+test -d "$GIT_COMMON_DIR"/rebase-merge -o -d "$GIT_COMMON_DIR"/rebase-apply && exit 0
 for enabled_plugin in $(git config --get-all hooks.enabled-plugins)
 do
-	if [ -f "$GIT_DIR/hooks/$enabled_plugin/post-checkout" ]
+	if [ -f "$GIT_COMMON_DIR/hooks/$enabled_plugin/post-checkout" ]
 	then
-		"$GIT_DIR/hooks/$enabled_plugin/post-checkout" "$1" "$2"
+		"$GIT_COMMON_DIR/hooks/$enabled_plugin/post-checkout" "$1" "$2"
 	fi
 done

--- a/template/hooks/post-commit
+++ b/template/hooks/post-commit
@@ -1,11 +1,11 @@
 #!/bin/bash -eu
-GIT_DIR=$(git rev-parse --git-common-dir)
-export GIT_DIR
-test -d "$GIT_DIR"/rebase-merge -o -d "$GIT_DIR"/rebase-apply && exit 0
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+export GIT_COMMON_DIR
+test -d "$GIT_COMMON_DIR"/rebase-merge -o -d "$GIT_COMMON_DIR"/rebase-apply && exit 0
 for enabled_plugin in $(git config --get-all hooks.enabled-plugins)
 do
-	if [ -f "$GIT_DIR/hooks/$enabled_plugin/post-commit" ]
+	if [ -f "$GIT_COMMON_DIR/hooks/$enabled_plugin/post-commit" ]
 	then
-		"$GIT_DIR/hooks/$enabled_plugin/post-commit"
+		"$GIT_COMMON_DIR/hooks/$enabled_plugin/post-commit"
 	fi
 done

--- a/template/hooks/post-merge
+++ b/template/hooks/post-merge
@@ -1,10 +1,10 @@
 #!/bin/bash -eu
-GIT_DIR=$(git rev-parse --git-common-dir)
-export GIT_DIR
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+export GIT_COMMON_DIR
 for enabled_plugin in $(git config --get-all hooks.enabled-plugins)
 do
-	if [ -f "$GIT_DIR/hooks/$enabled_plugin/post-merge" ]
+	if [ -f "$GIT_COMMON_DIR/hooks/$enabled_plugin/post-merge" ]
 	then
-		"$GIT_DIR/hooks/$enabled_plugin/post-merge" "$1"
+		"$GIT_COMMON_DIR/hooks/$enabled_plugin/post-merge" "$1"
 	fi
 done

--- a/template/hooks/pre-commit
+++ b/template/hooks/pre-commit
@@ -1,13 +1,13 @@
 #!/bin/bash -eu
-GIT_DIR=$(git rev-parse --git-common-dir)
-export GIT_DIR
-test -f "$GIT_DIR"/CHERRY_PICK_HEAD && exit 0
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+export GIT_COMMON_DIR
+test -f "$GIT_COMMON_DIR"/CHERRY_PICK_HEAD && exit 0
 for enabled_plugin in $(git config --get-all hooks.enabled-plugins)
 do
-	if [ -f "$GIT_DIR/hooks/$enabled_plugin/pre-commit" ]
+	if [ -f "$GIT_COMMON_DIR/hooks/$enabled_plugin/pre-commit" ]
 	then
 
-		if ! "$GIT_DIR/hooks/$enabled_plugin/pre-commit"
+		if ! "$GIT_COMMON_DIR/hooks/$enabled_plugin/pre-commit"
 		then
 			exit 1
 		fi

--- a/template/hooks/syntaxchecker/pre-commit
+++ b/template/hooks/syntaxchecker/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
-GIT_DIR=$(git rev-parse --git-common-dir)
-. "$GIT_DIR/hooks/git_config_wrapper.sh"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+. "$GIT_COMMON_DIR/hooks/git_config_wrapper.sh"
 if git rev-parse --verify HEAD >/dev/null 2>&1; then
 	against=HEAD
 else
@@ -10,9 +10,9 @@ fi
 for FILE in $(git diff-index --cached --name-status $against -- | cut -c 3-); do
 	if [ -f "$FILE" ]
 	then
-		if [ -f "$GIT_DIR/hooks/syntaxchecker/${FILE##*.}.sh" ]
+		if [ -f "$GIT_COMMON_DIR/hooks/syntaxchecker/${FILE##*.}.sh" ]
 		then
-			source "$GIT_DIR/hooks/syntaxchecker/${FILE##*.}.sh"
+			source "$GIT_COMMON_DIR/hooks/syntaxchecker/${FILE##*.}.sh"
 			if [ $? -ne 0 ]
 			then
 				echo 'Problem while parsing file ' "$FILE"

--- a/template/hooks/ticketref/commit-msg
+++ b/template/hooks/ticketref/commit-msg
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck source=../git_config_wrapper.sh
-GIT_DIR=$(git rev-parse --git-common-dir)
-. "$GIT_DIR/hooks/git_config_wrapper.sh"
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+. "$GIT_COMMON_DIR/hooks/git_config_wrapper.sh"
 
 get_hook_config ticketref position REF_LOC optional PRE
 


### PR DESCRIPTION
When using git worktrees, GIT_DIR and GIT_COMMON_DIR can differ. In that
kind of case, it's a very bad idea to set GIT_DIR to GIT_COMMON_DIR.